### PR TITLE
Upgrade to shapeless 2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.11.5"
 
 libraryDependencies ++= Seq(
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-        "com.chuusai" %% "shapeless" % "2.1.0-RC2",
+        "com.chuusai" %% "shapeless" % "2.1.0",
         "org.scalatest" %% "scalatest" % "2.2.4" % "test",
         "org.specs2" %% "specs2-core" % "2.4.16" % "test",
         "junit" % "junit" % "4.12" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ publishTo <<= version { v: String =>
 
 resolvers ++= Seq("snapshots", "releases").map(Resolver.sonatypeRepo)
 
-//publishMavenStyle := true
+publishMavenStyle := true
 
 publishArtifact in Test := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,16 +2,16 @@ name := "persist-json"
 
 organization := "com.persist"
 
-version := "0.20"
+version := "0.21-SNAPSHOT"
 
-scalaVersion := "2.11.1"
+scalaVersion := "2.11.5"
 
 libraryDependencies ++= Seq(
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-        "com.chuusai" %% "shapeless" % "2.0.0",
-        "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-        "org.specs2" %% "specs2" % "2.4.2" % "test",
-        "junit" % "junit" % "4.11" % "test"
+        "com.chuusai" %% "shapeless" % "2.1.0-RC2",
+        "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+        "org.specs2" %% "specs2-core" % "2.4.16" % "test",
+        "junit" % "junit" % "4.12" % "test"
 )
 
 publishTo <<= version { v: String =>
@@ -22,7 +22,9 @@ publishTo <<= version { v: String =>
     Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
-publishMavenStyle := true
+resolvers ++= Seq("snapshots", "releases").map(Resolver.sonatypeRepo)
+
+//publishMavenStyle := true
 
 publishArtifact in Test := false
 
@@ -50,3 +52,7 @@ pomExtra := (
     </developer>
   </developers>
 )
+
+seq(bintraySettings:_*)
+
+bintray.Keys.bintrayOrganization in bintray.Keys.bintray := Some("whitepages")

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,3 @@ pomExtra := (
     </developer>
   </developers>
 )
-
-seq(bintraySettings:_*)
-
-bintray.Keys.bintrayOrganization in bintray.Keys.bintray := Some("whitepages")

--- a/src/main/scala/com/persist/JsonFormat.scala
+++ b/src/main/scala/com/persist/JsonFormat.scala
@@ -260,7 +260,7 @@ package object json {
         def write(ft: F :: T) = {
           val head = FHead.write(ft.head)
           val tail = FTail.write(ft.tail).asInstanceOf[JsonObject]
-          tail + (name -> head)
+          if (head == jnull) tail else tail + (name -> head)
         }
       }
 
@@ -269,19 +269,6 @@ package object json {
       }
     }
   }
-
-  implicit def deriveHConsOption[K <: Symbol, V, T <: HList]
-  (implicit
-   key: Witness.Aux[K],
-   headCodec: Lazy[WriteCodec[V]],
-   tailCodec: Lazy[WriteCodec[T]]
-    ): WriteCodec[FieldType[K, Option[V]] :: T] =
-    new WriteCodec[FieldType[K, Option[V]] :: T] {
-      def write(ft: FieldType[K, Option[V]] :: T): Json = {
-        val tail = tailCodec.value.write(ft.tail).asInstanceOf[JsonObject]
-        ft.head.map(someHead => tail + (key.value.name -> headCodec.value.write(someHead))).getOrElse(tail)
-      }
-    }
 
   def toJson[T](obj: T)(implicit codec: WriteCodec[T]): Json = codec.write(obj)
   def read[T](json: Json)(implicit codec: ReadCodec[T]): T = codec.read(json)

--- a/src/main/scala/com/persist/JsonFormat.scala
+++ b/src/main/scala/com/persist/JsonFormat.scala
@@ -176,8 +176,8 @@ package object json {
     implicit def deriveHCons[K <: Symbol, V: TypeTag, T <: HList]
     (implicit
      key: Witness.Aux[K],
-     readCodec: Lazy[ReadCodec[V]],
-     writeCodec: Lazy[ReadCodec[T]]
+     headCodec: Lazy[ReadCodec[V]],
+     tailCodec: Lazy[ReadCodec[T]]
       ): ReadCodec[FieldType[K, V] :: T] = new ReadCodec[FieldType[K, V] :: T] {
         def read(json: Json): FieldType[K, V] :: T = {
           val map = castOrThrow(json)
@@ -190,8 +190,8 @@ package object json {
           // If we get a mapping exception, intercept it and add the name of this field to the path
           // If we get another exception, don't touch!
           // Pitfall: if handle did not accept a PartialFunction, we could transform an unknown exception into a match exception
-          val head: V = Try(readCodec.value.read(fieldValue)).recover{ case MappingException(msg, path) => throw MappingException(msg, s"$name/$path")}.get
-          val tail = writeCodec.value.read(json)
+          val head: V = Try(headCodec.value.read(fieldValue)).recover{ case MappingException(msg, path) => throw MappingException(msg, s"$name/$path")}.get
+          val tail = tailCodec.value.read(json)
           field[K](head) :: tail
         }
       }

--- a/src/test/scala/com/persist/ErrorHandling.scala
+++ b/src/test/scala/com/persist/ErrorHandling.scala
@@ -35,15 +35,9 @@ class ErrorHandlingTest extends Specification {
   val individual = Individual4("Bill", Some(45), Some(Ref4("Bob")))
   val expectedP = JsonObject("name" -> "Bill", "age" -> 45, "friend" -> JsonObject("name" -> "Bob"))
 
-  //import ReadCodec.auto._
-
-  implicit val ref: ReadCodec[Ref4] = ReadCodec[Ref4]
-  implicit val ind = LabelledGeneric[Individual4]
-
   "error handling" should {
     "missing field" in {
       "simple" in {
-        import ReadCodec._
         val json_ = JsonObject("name1" -> "Bill", "age" -> 45)
 
         json.read[Individual4](json_) must throwA[MappingException].like { case ex =>
@@ -61,7 +55,7 @@ class ErrorHandlingTest extends Specification {
         val json_ = JsonObject("name" -> "Bill", "age" -> 45)
 
         json.read[Individual4](json_) ==== Individual4("Bill", Some(45), None)
-      }.pendingUntilFixed("Need to fix the compiler for this :P")
+      }
     }
     "wrong type" in {
       val json_ = JsonObject("name" -> 45, "age" -> 45, "friend" -> JsonObject("name" -> "Bob"))

--- a/src/test/scala/com/persist/ErrorHandling.scala
+++ b/src/test/scala/com/persist/ErrorHandling.scala
@@ -41,14 +41,14 @@ class ErrorHandlingTest extends Specification {
         val json_ = JsonObject("name1" -> "Bill", "age" -> 45)
 
         json.read[Individual4](json_) must throwA[MappingException].like { case ex =>
-          ex ==== MappingException(s"Expected field name on JsonObject $json_", "")
+          ex ==== MappingException(s"""Expected field "name" on JsonObject $json_""", "")
         }
       }
       "nested" in {
         val json_ = JsonObject("name" -> "Bill", "age" -> 45, "friend" -> JsonObject("name1" -> "Bob"))
 
         json.read[Individual4](json_) must throwA[MappingException].like { case ex =>
-          ex ==== MappingException(s"""Expected field name on JsonObject Map(name1 -> Bob)""", "friend/")
+          ex ==== MappingException(s"""Expected field "name" on JsonObject Map(name1 -> Bob)""", "friend/")
         }
       }
       "optional" in {

--- a/src/test/scala/com/persist/ErrorHandling.scala
+++ b/src/test/scala/com/persist/ErrorHandling.scala
@@ -21,6 +21,8 @@ import com.persist.Exceptions.MappingException
 import com.persist.json.ReadCodec
 import org.specs2.mutable._
 import com.persist.JsonOps._
+import shapeless._
+import syntax.singleton._
 
 case class Ref4(name: String)
 case class Individual4(name: String, age: Option[Int], friend: Option[Ref4])
@@ -35,12 +37,13 @@ class ErrorHandlingTest extends Specification {
 
   //import ReadCodec.auto._
 
-  implicit val ref = ReadCodec[Ref4]
-  implicit val ind = ReadCodec[Individual4]
+  implicit val ref: ReadCodec[Ref4] = ReadCodec[Ref4]
+  implicit val ind = LabelledGeneric[Individual4]
 
   "error handling" should {
     "missing field" in {
       "simple" in {
+        import ReadCodec._
         val json_ = JsonObject("name1" -> "Bill", "age" -> 45)
 
         json.read[Individual4](json_) must throwA[MappingException].like { case ex =>

--- a/src/test/scala/com/persist/JsonFormatTest.scala
+++ b/src/test/scala/com/persist/JsonFormatTest.scala
@@ -32,6 +32,10 @@ case class Meetup1(city: String, people: Seq[Individual], cnt: Int, props: Map[S
 case class Meetup2(city: String, people: Seq[Individual], cnt: Int)
 case class ByteTest(buffer: ByteBuffer)
 
+sealed trait Animal
+case class Dog(age: Int, name: String, master: String) extends Animal
+case class Cat(age: Int, name: String, slave: String) extends Animal
+
 case class FullTrip(s: Short, l: Long)
 
 class JsonFormatTest extends Specification {
@@ -115,6 +119,12 @@ class JsonFormatTest extends Specification {
       val expected = JsonObject("name" -> "Ye", "friend" -> JsonObject("name" -> "Yu"))
       json.toJson(individual1) ==== expected
       individual1 ==== json.read[Individual](expected)
+    }
+    "ADT" in {
+      val animal: Animal = Dog(5, "Yoyo", "Ben")
+      val expected = JsonObject("age" -> 5, "name" -> "Yoyo", "master" -> "Ben")
+      json.toJson(animal) ==== expected
+      animal ==== json.read[Animal](expected)
     }
   }
 }

--- a/src/test/scala/com/persist/JsonFormatTest.scala
+++ b/src/test/scala/com/persist/JsonFormatTest.scala
@@ -22,6 +22,8 @@ import java.nio.ByteBuffer
 import com.persist.json.{ReadWriteCodec, ReadCodec, WriteCodec}
 import org.specs2.mutable._
 import com.persist.JsonOps._
+import shapeless._
+import syntax.singleton._
 
 case class Ref(name: String)
 case class Individual(name: String, age: Option[Int], friend: Option[Ref])
@@ -32,15 +34,19 @@ case class ByteTest(buffer: ByteBuffer)
 
 case class FullTrip(s: Short, l: Long)
 
+object Codecs {
+  implicit val ref: ReadCodec[ByteTest] = ReadCodec[ByteTest]
+  implicit val blablabla: ReadCodec[FullTrip] = ReadCodec[FullTrip]
+}
+
 class JsonFormatTest extends Specification {
 
+  import Codecs._
   val individual = Individual("Bill", Some(45), Some(Ref("Bob")))
   val expectedP = JsonObject("name" -> "Bill", "age" -> 45, "friend" -> JsonObject("name" -> "Bob"))
 
   "JsonFormat" should {
     "automatic codec generation" in {
-      import WriteCodec.auto.{derive => writeDerive}
-      import ReadCodec.auto.{derive => readDerive}
       "simple" in {
 
         val p = Individual("Bill", Some(45), Some(Ref("Bob")))
@@ -89,8 +95,8 @@ class JsonFormatTest extends Specification {
         val jsonValue = json.toJson(test)
         val stringValue = Compact(jsonValue)
         val otherJsonValue = Json(stringValue)
-        implicit val ft = ReadCodec[FullTrip]
-        val otherTest = json.read[FullTrip](otherJsonValue)
+
+        val otherTest = blablabla.read(otherJsonValue)//json.read[FullTrip](otherJsonValue)
         test ==== otherTest
       }
       "Integer" in {
@@ -113,8 +119,8 @@ class JsonFormatTest extends Specification {
       optionTest ==== Some(FullTrip(1,1))
     }
     "byteBuffer" in {
-      implicit val writeCodec = WriteCodec[ByteTest]
-      implicit val readCodec = ReadCodec[ByteTest]
+      //implicit val writeCodec1: WriteCodec[ByteTest] = WriteCodec[ByteTest]
+      //
 
       val obj = ByteTest(ByteBuffer.wrap(Array[Byte](1,2,3,4,5,6)))
       val jsonThing = json.toJson(obj)


### PR DESCRIPTION
At the same time I fixed up a few things:

- Add support for ADTs
- Better support for Option serialization and de-serialization in default Codecs

Shapeless 2.1 should come out within the next few days. The major change from 2.0 is the typeclass derivation mechanism (which is what we are using it for) so had some fun updating to the new API (it's better so it's all good)

I suggest merging this PR (we can review together and with others) and then doing a release when Shapeless 2.1 officially comes out (like I said a few days probably). It's currently built with 2.1-RC2.