### PR TITLE
Enable json strings to contain doubles

### DIFF
--- a/src/main/scala/com/persist/JsonFormat.scala
+++ b/src/main/scala/com/persist/JsonFormat.scala
@@ -92,8 +92,10 @@ package object json {
     implicit val double = new ReadCodec[Double] {
       def read(x: Json): Double = x match {
         case x: Int => x.toDouble
+        case x: Float => x.toDouble
         case x: Short => x.toDouble
         case x: Long => x.toDouble
+        case x: BigDecimal => x.toDouble
         case x: Double => x
         case _ => throw new MappingException(s"Expected: Double, but found $x")
       }
@@ -105,6 +107,7 @@ package object json {
         case x: Int => x.toFloat
         case x: Short => x.toFloat
         case x: Long => x.toFloat
+        case x: BigDecimal => x.toFloat
         case _ => throw new MappingException(s"Expected Float, but found $x")
       }
     }

--- a/src/test/scala/com/persist/JsonFormatTest.scala
+++ b/src/test/scala/com/persist/JsonFormatTest.scala
@@ -30,7 +30,7 @@ case class Meetup1(city: String, people: Seq[Individual], cnt: Int, props: Map[S
 case class Meetup2(city: String, people: Seq[Individual], cnt: Int)
 case class ByteTest(buffer: ByteBuffer)
 
-case class FullTrip(s: Short, l: Long)
+case class FullTrip(s: Short, l: Long, d: Double)
 
 class JsonFormatTest extends Specification {
 
@@ -85,7 +85,7 @@ class JsonFormatTest extends Specification {
       //      j ==== expected
       //    }
       "full trip" in {
-        val test = FullTrip(4, 4)
+        val test = FullTrip(4, 4, 1.1)
         val jsonValue = json.toJson(test)
         val stringValue = Compact(jsonValue)
         val otherJsonValue = Json(stringValue)
@@ -106,11 +106,11 @@ class JsonFormatTest extends Specification {
     }
     "read and readWrite" in {
       implicit val codec = new ReadWriteCodec[FullTrip] {
-        def read(j: Json): FullTrip = FullTrip(1,1)
+        def read(j: Json): FullTrip = FullTrip(1,1,1.1)
         def write(obj: FullTrip): Json = Map()
       }
-      val optionTest = json.read[Option[FullTrip]](JsonObject("s" -> 4, "l" -> 4))
-      optionTest ==== Some(FullTrip(1,1))
+      val optionTest = json.read[Option[FullTrip]](JsonObject("s" -> 4, "l" -> 4, "d" -> 1.1))
+      optionTest ==== Some(FullTrip(1,1,1.1))
     }
     "byteBuffer" in {
       implicit val writeCodec = WriteCodec[ByteTest]


### PR DESCRIPTION
Json strings containing doubles (e.g. "1.1") throw an exception. This fixes that and adds a validation test.